### PR TITLE
Add /add-level slash command for curriculum development

### DIFF
--- a/.claude/commands/add-exercise.md
+++ b/.claude/commands/add-exercise.md
@@ -1,0 +1,96 @@
+---
+description: Add a new exercise from .todo/exercises.md to the curriculum
+---
+
+# Add Next Exercise from Todo List
+
+I'll help you add the next exercise from `.todo/exercises.md` to the curriculum. Let me start by reading the todo file and understanding what exercise needs to be implemented.
+
+## Step 1: Read the todo file
+
+First, let me check what's the next exercise to implement:
+
+```bash
+cat .todo/exercises.md
+```
+
+## Step 2: Planning Phase
+
+Based on the exercise found in the todo file, I'll ask you some clarifying questions:
+
+1. **Exercise Mechanics**:
+   - What should the player/character be able to do? (e.g., move, jump, rotate, etc.)
+   - What visual elements should be displayed on screen?
+   - How should the exercise respond to each available function?
+
+2. **Available Functions**:
+   - What functions should be exposed to the learner?
+   - What should each function do (visually and in state)?
+   - Should functions have parameters? If so, what type and range?
+   - Any timing/duration for animations?
+
+3. **State Management**:
+   - What state properties need to be tracked? (e.g., position, rotation, score)
+   - What are the initial values for each state property?
+   - Are there any constraints or limits? (e.g., boundaries, max values)
+
+4. **Visual Design**:
+   - What should the exercise container look like?
+   - What CSS styles and layout should be used?
+   - Should there be any background, grid, or reference markers?
+   - What colors/themes align with the exercise concept?
+
+5. **Scenarios** (if applicable):
+   - Should this exercise have different difficulty levels or scenarios?
+   - What changes between scenarios? (e.g., starting position, goals, constraints)
+   - How do scenarios relate to the level's learning objectives?
+
+6. **Learning Objectives**:
+   - What programming concept does this exercise teach?
+   - How does it fit into the current curriculum progression?
+   - What skills should learners gain from completing this exercise?
+
+## Step 3: Implementation Plan
+
+After gathering your answers, I'll present a detailed plan showing:
+
+1. **Exercise folder structure** at `src/exercises/[exercise-name]/`:
+   - `Exercise.ts` - Main exercise class implementation
+   - `scenarios.ts` - Different scenarios/difficulty levels (if needed)
+   - `index.ts` - Module exports
+
+2. **Exercise class design** including:
+   - State properties and their initial values
+   - Available functions with descriptions
+   - Animation logic for each function
+   - View generation with HTML/CSS
+
+3. **Integration points**:
+   - Export from `src/exercises/index.ts`
+   - Type definitions if needed
+   - How it connects to levels/lessons
+
+## Step 4: Implementation
+
+Once you approve the plan, I'll implement the exercise by:
+
+1. Creating the exercise folder and files
+2. Implementing the Exercise class with:
+   - State management
+   - Available functions
+   - Animation generation
+   - View population
+3. Adding scenarios if applicable
+4. Exporting from the exercises index
+5. Running tests to ensure everything works
+
+## Step 5: Testing
+
+After implementation, I'll:
+
+- Build the package to check for TypeScript errors
+- Run any existing tests
+- Verify the exercise structure matches existing patterns
+- Ensure animations and state work correctly
+
+Let's begin by examining the todo file and determining the next exercise to implement.

--- a/.claude/commands/add-level.md
+++ b/.claude/commands/add-level.md
@@ -1,0 +1,56 @@
+---
+description: Add a new level from .todo/levels.md to the curriculum
+---
+
+# Add Next Level from Todo List
+
+I'll help you add the next level from `.todo/levels.md` to the curriculum. Let me start by reading the todo file and understanding what level needs to be implemented.
+
+## Step 1: Read the todo file
+
+First, let me check what's the next level to implement:
+
+```bash
+cat .todo/levels.md
+```
+
+## Step 2: Planning Phase
+
+Based on the level found in the todo file, I'll ask you some clarifying questions:
+
+1. **JavaScript Node Types**: Which AST node types should be allowed for this level? Should it build upon the previous level's allowed nodes?
+
+2. **Feature Flags**: What language feature flags should be set? Common options include:
+   - `allowShadowing`: Allow variable shadowing?
+   - `requireVariableInstantiation`: Require variables to be initialized?
+   - `allowTruthiness`: Allow truthy/falsy checks?
+   - `allowTypeCoercion`: Allow type coercion?
+   - `enforceStrictEquality`: Enforce === over ==?
+   - `oneStatementPerLine`: Enforce one statement per line?
+
+3. **Level Structure**:
+   - Should this level build incrementally on the previous level's features?
+   - What's the main learning objective for this level?
+   - Any specific exercises or lessons you'd like to reference (even if not implemented yet)?
+
+4. **Description**: What description should be used for the level to explain what students will learn?
+
+## Step 3: Implementation Plan
+
+After gathering your answers, I'll present a detailed plan showing:
+
+1. **The new level file** that will be created at `src/syllabus/levels/[level-name].ts`
+2. **The level configuration** including:
+   - ID, title, and description
+   - Allowed JavaScript nodes
+   - Feature flags
+   - Empty lessons array (as requested)
+3. **Syllabus integration** - how it will be added to `src/syllabus/syllabus.ts`
+
+Once you approve the plan, I'll implement the level by:
+
+- Creating the new level file with the agreed configuration
+- Importing it in the syllabus
+- Adding it to the syllabus array in the correct position
+
+Let's begin by examining the todo file and determining the next level to implement.

--- a/.todo/exercises.md
+++ b/.todo/exercises.md
@@ -1,0 +1,11 @@
+# Exercises
+
+Take the next exercise (with a ## heading below) and turn it into a new exercise.
+
+## Example: Simple Counter
+
+Create an exercise where the learner can increment and decrement a counter displayed on screen. This teaches basic state manipulation and function calls.
+
+- Functions: increment(), decrement(), reset()
+- Visual: Display a large number that changes
+- State: Track current count value


### PR DESCRIPTION
## Summary
- Adds a new `/add-level` slash command to streamline curriculum development
- Command reads from `.todo/levels.md` to determine the next level to implement
- Includes interactive planning phase with user approval before making changes

## Features
- **Interactive workflow**: Asks clarifying questions about JavaScript node types, feature flags, and level structure
- **Planning phase**: Presents a detailed implementation plan for user approval
- **Automated creation**: Creates the level file in `src/syllabus/levels/` and integrates it into the syllabus

## Usage
After session restart, use `/add-level` to:
1. Read the next level from `.todo/levels.md`
2. Answer clarifying questions about configuration
3. Review and approve the implementation plan
4. Automatically create and integrate the new level

🤖 Generated with [Claude Code](https://claude.com/claude-code)